### PR TITLE
feat: add files related endpoints

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
-import { OpenAPI, OrganizationService } from './src/api/client/index.js';
+import { OpenAPI, OrganizationService, RepositoryService } from './src/api/client/index.js';
 
 OpenAPI.BASE = 'https://app.codacy.com/api/v3';
 OpenAPI.HEADERS = {
@@ -54,6 +54,120 @@ const listOrganizationRepositoriesTool: Tool = {
   },
 };
 
+//File endpoints
+const listFilesTool: Tool = {
+  name: 'codacy_list_files',
+  description: 'List files in a repository with pagination',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      provider: {
+        type: 'string',
+        description:
+          "Organization's git provider: GitHub (gh), GitLab (gl) or BitBucket (bb). Accepted values: gh, gl, bb.",
+      },
+      organization: {
+        type: 'string',
+        description: 'Organization name on the Git provider',
+      },
+      repository: {
+        type: 'string',
+        description: 'Repository name on the Git provider organization',
+      },
+      branch: {
+        type: 'string',
+        description: 'Name of a repository branch enabled on Codacy',
+      },
+      search: {
+        type: 'string',
+        description: 'Filter files that include this string anywhere in their relative path',
+      },
+      sort: {
+        type: 'string',
+        description:
+          "Field used to sort the list of files. The allowed values are 'filename', 'issues', 'grade', 'duplication', 'complexity', and 'coverage'.",
+      },
+      direction: {
+        type: 'string',
+        description:
+          "Sort direction. Possible values are 'asc' (ascending) or 'desc' (descending).",
+      },
+      cursor: {
+        type: 'string',
+        description: 'Pagination cursor for next page of results',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results to return (default 100, max 100)',
+        default: 100,
+      },
+    },
+  },
+};
+
+const getFileIssuesTool: Tool = {
+  name: 'codacy_get_file_issues',
+  description: 'Get the issue list for a file in a repository',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      provider: {
+        type: 'string',
+        description:
+          "Organization's git provider: GitHub (gh), GitLab (gl) or BitBucket (bb). Accepted values: gh, gl, bb.",
+      },
+      organization: {
+        type: 'string',
+        description: 'Organization name on the Git provider',
+      },
+      repository: {
+        type: 'string',
+        description: 'Repository name on the Git provider organization',
+      },
+      fileId: {
+        type: 'string',
+        description: 'Identifier of a file in a specific commit',
+      },
+      cursor: {
+        type: 'string',
+        description: 'Pagination cursor for next page of results',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results to return (default 100, max 100)',
+        default: 100,
+      },
+    },
+  },
+};
+
+const getFileCoverageTool: Tool = {
+  name: 'codacy_get_file_coverage',
+  description: 'Get coverage information for a file in the head commit of a repository branch.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      provider: {
+        type: 'string',
+        description:
+          "Organization's git provider: GitHub (gh), GitLab (gl) or BitBucket (bb). Accepted values: gh, gl, bb.",
+      },
+      organization: {
+        type: 'string',
+        description: 'Organization name on the Git provider',
+      },
+      repository: {
+        type: 'string',
+        description: 'Repository name on the Git provider organization',
+      },
+      fileId: {
+        type: 'string',
+        description: 'Identifier of a file in a specific commit',
+      },
+    },
+  },
+};
+
 const listOrganizationRepositoriesHandler = async (args: any) => {
   const { provider, organization, limit, cursor } = args;
 
@@ -65,10 +179,50 @@ const listOrganizationRepositoriesHandler = async (args: any) => {
   );
 };
 
+const listFilesHandler = async (args: any) => {
+  const { provider, organization, repository, branch, search, sort, direction, cursor, limit } =
+    args;
+  return await RepositoryService.listFiles(
+    provider,
+    organization,
+    repository,
+    branch,
+    search,
+    sort,
+    direction,
+    cursor,
+    limit
+  );
+};
+
+const getFileIssuesHandler = async (args: any) => {
+  const { provider, organization, repository, fileId, limit, cursor } = args;
+
+  return await RepositoryService.getFileIssues(
+    provider,
+    organization,
+    repository,
+    fileId,
+    limit,
+    cursor
+  );
+};
+
+const getFileCoverageHandler = async (args: any) => {
+  const { provider, organization, repository, fileId } = args;
+
+  return await RepositoryService.getFileCoverage(provider, organization, repository, fileId);
+};
+
 // Register tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
-    tools: [listOrganizationRepositoriesTool],
+    tools: [
+      listOrganizationRepositoriesTool,
+      listFilesTool,
+      getFileIssuesTool,
+      getFileCoverageTool,
+    ],
   };
 });
 
@@ -82,6 +236,24 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
     switch (request.params.name) {
       case 'codacy_list_repositories': {
         const result = await listOrganizationRepositoriesHandler(request.params.arguments);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      case 'codacy_list_files': {
+        const result = await listFilesHandler(request.params.arguments);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      case 'codacy_get_file_issues': {
+        const result = await getFileIssuesHandler(request.params.arguments);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      case 'codacy_get_file_coverage': {
+        const result = await getFileCoverageHandler(request.params.arguments);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };


### PR DESCRIPTION
## list files in a repo:

<img width="767" alt="Screenshot 2025-03-26 at 12 32 15" src="https://github.com/user-attachments/assets/17449fa7-05d3-46c9-9689-af844c97d52f" />

## use search to find a specific file:

<img width="778" alt="Screenshot 2025-03-26 at 12 33 33" src="https://github.com/user-attachments/assets/354012ad-335c-4dbc-b4fb-1fd7df77214f" />

## list issues in that file: 

<img width="815" alt="Screenshot 2025-03-26 at 12 38 08" src="https://github.com/user-attachments/assets/034d568c-81be-4800-a427-9be56cb2125e" />

the file really doesn't have issues:

<img width="1416" alt="Screenshot 2025-03-26 at 12 35 04" src="https://github.com/user-attachments/assets/7f4e9ee6-ea86-4ad6-b2c9-d72d23e92258" />

## get coverage for that file:

<img width="769" alt="Screenshot 2025-03-26 at 12 35 35" src="https://github.com/user-attachments/assets/f979154f-cddc-48da-a643-b53ae30adebf" />

