### PR TITLE
fix: list organizations

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -139,7 +139,7 @@ const toolDefinitions: { [key in ToolKeys]: ToolDefinition } = {
     tool: Tools.listRepositoryToolsTool,
     handler: Handlers.listRepositoryToolsHandler,
   },
-  codacy_list_organization: {
+  codacy_list_organizations: {
     tool: Tools.listOrganizationsTool,
     handler: Handlers.listOrganizationsHandler,
   },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,7 +28,7 @@ export type ToolKeys =
   | 'codacy_list_repository_tool_patterns'
   | 'codacy_list_repository_tools'
   | 'codacy_list_tools'
-  | 'codacy_list_organization'
+  | 'codacy_list_organizations'
   | 'codacy_get_file_issues'
   | 'codacy_get_file_coverage'
   | 'codacy_get_repository_pull_request_files_coverage'


### PR DESCRIPTION
use plural everywhere