### PR TITLE
fix(deps): bump @modelcontextprotocol/sdk to 1.29.0 to resolve CVE-2026-25536

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inspect": "npm run build && npx @modelcontextprotocol/inspector -e CODACY_ACCOUNT_TOKEN=$CODACY_ACCOUNT_TOKEN node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@types/node": "^22",
     "@types/sarif": "2.1.7",
     "undici": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inspect": "npm run build && npx @modelcontextprotocol/inspector -e CODACY_ACCOUNT_TOKEN=$CODACY_ACCOUNT_TOKEN node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.25.2",
+    "@modelcontextprotocol/sdk": "1.25.3",
     "@types/node": "^22",
     "@types/sarif": "2.1.7",
     "undici": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inspect": "npm run build && npx @modelcontextprotocol/inspector -e CODACY_ACCOUNT_TOKEN=$CODACY_ACCOUNT_TOKEN node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.25.3",
+    "@modelcontextprotocol/sdk": "1.29",
     "@types/node": "^22",
     "@types/sarif": "2.1.7",
     "undici": "^6.0.0",


### PR DESCRIPTION
## Summary

Bumps `@modelcontextprotocol/sdk` from its currently pinned version to `1.29.0`
to resolve a high-severity security advisory. 1.29.0 was chosen over the
minimum patched version (1.26.0) to pick up the latest stable release in
that line without major changes.

## Motivation

`npm audit` (and GitHub's advisory scanning) flags the current SDK version
range (1.10.0–1.25.3) with a **High** severity finding:

**[GHSA-345p-7cg4-v4c7](https://github.com/advisories/GHSA-345p-7cg4-v4c7)** —
Cross-client data leak via shared server/transport instance reuse
(CVSS 7.1, CVE-2026-25536)
